### PR TITLE
Fix a problem with psql 9.4 where an atom is not accepted as an argument for the status update query.

### DIFF
--- a/models/m_payment.erl
+++ b/models/m_payment.erl
@@ -378,7 +378,7 @@ set_payment_status(PaymentId, Status, StatusDate, Context) ->
                           and status <> $1
                           and (   status_date is null
                                or status_date <= $3)",
-                        [Status, PaymentId, StatusDate],
+                        [z_convert:to_binary(Status), PaymentId, StatusDate],
                         Ctx)
                     of
                         0 -> {ok, unchanged};


### PR DESCRIPTION
On psql 9.4 we got the following error:

```
z_db error {error,error,<<"42P08">>,ambiguous_parameter,<<"inconsistent types deduced for parameter $1">>,[{detail,<<"text versus character varying">>},{file,<<"parse_param.c">>},{line,<<"221">>},{position,<<"78">>},{routine,<<"variable_coerce_param_hook">>}]} in query 
                        update payment
                        set status = $1,
                            status_date = $3
                        where id = $2
                          and status <> $1
                          and (   status_date is null
                               or status_date <= $3) with [paid,2544,{{2021,8,24},{22,15,11}}]
```

The assumption is that if we make the `paid` a binary string that the error will be fixed.