### PR TITLE
Fix a problem with older psql versions where a type coercion occured during status updates.

### DIFF
--- a/models/m_payment.erl
+++ b/models/m_payment.erl
@@ -372,10 +372,10 @@ set_payment_status(PaymentId, Status, StatusDate, Context) ->
                 _OldStatus ->
                     case z_db:q("
                         update payment
-                        set status = $1,
+                        set status = $1::varchar,
                             status_date = $3
                         where id = $2
-                          and status <> $1
+                          and status <> $1::varchar
                           and (   status_date is null
                                or status_date <= $3)",
                         [z_convert:to_binary(Status), PaymentId, StatusDate],


### PR DESCRIPTION
The error was:

```
{error,{error,error,<<"42P08">>,ambiguous_parameter,
                                  <<"inconsistent types deduced for parameter $1">>,
                                  [{detail,<<"text versus character varying">>},
                                   {file,<<"parse_param.c">>},
                                   {line,<<"221">>},
                                   {position,<<"30">>},
                                   {routine,<<"variable_coerce_param_hook">>}]}}
```

Which occurred because in the query:

```
update payment
set status = $1,
    status_date = $3
where id = $2
  and status <> $1
  and (   status_date is null
       or status_date <= $3)",
[<<"paid">>,999999999,{{2021,9,21},{7,51,29}}],
```

Parameter `$1` is found to be of type `text` in the update and then of type `varchar` in the where clause.

This doesn't happen on psql 10 and newer, probably only on 8 and earlier.

The explicit types in this change fix the issue.